### PR TITLE
Corrected the Java README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ import java.io.Reader;
 import java.util.zip.GZIPInputStream;
 
 public class MessageHandler implements MessageListener {
+
+    private static final Logger LOG = Logger.getLogger(MessageHandler.class.getName());
+
     @Override
     public void onMessage(Message message) {
         String xmlString = convertToXmlString((BytesMessage) message);
@@ -102,18 +105,18 @@ public class MessageHandler implements MessageListener {
 
     private String convertToXmlString(BytesMessage bytesMessage) {
         if (bytesMessage != null) try {
-            long l = bytesMessage.getBodyLength();
-            byte bytesArray[] = new byte[(int) l];
+            long length = bytesMessage.getBodyLength();
+            byte[] bytesArray = new byte[(int) length];
             bytesMessage.readBytes(bytesArray);
             Reader streamReader = null;
             try {
                 streamReader = new InputStreamReader(new GZIPInputStream(new ByteArrayInputStream(bytesArray)));
                 StringBuilder stringBuilder = new StringBuilder();
-                char cb[] = new char[1024];
-                int s = streamReader.read(cb);
-                while (s > -1) {
-                    stringBuilder.append(cb, 0, s);
-                    s = streamReader.read(cb);
+                char[] charBuffer = new char[1024];
+                int size = streamReader.read(charBuffer);
+                while (size > -1) {
+                    stringBuilder.append(cb, 0, size);
+                    size = streamReader.read(charBuffer);
                 }
                 return stringBuilder.toString();
             } catch (IOException e) {
@@ -124,11 +127,9 @@ public class MessageHandler implements MessageListener {
                 }
             }
         } catch (IOException ex) {
-            System.out.println("Failed to parse message");
-            ex.printStackTrace();
+            LOG.log(Level.SEVERE, null, ex);
         } catch (JMSException ex) {
-            System.out.println("Failed to parse message");
-            ex.printStackTrace();
+            LOG.log(Level.SEVERE, null, ex);
         }
 
         return null;


### PR DESCRIPTION
Corrected the array creation lines as the square brackets were on the object identifier and not the object type and thus could not be compiled.
Renamed the short variables to be more representative of their purpose and make the code example easier to read.
Added an instance of the standard logger to report exceptions rather than using System.out.